### PR TITLE
chore: add agent creator instructions

### DIFF
--- a/codex_add-agent-creator-2025-08-07.md
+++ b/codex_add-agent-creator-2025-08-07.md
@@ -1,0 +1,31 @@
+Objectif
+--------
+Créer un composant React `AgentCreator` permettant d'appeler les commandes Tauri `create_agent` et `list_agents`, d'intégrer `AgentCard`, d'uploader des connaissances et de choisir un modèle.
+
+Contexte
+--------
+Le projet `super-agent-party` manque d'une interface pour créer et lister des agents via Tauri. Le composant devra initialiser le formulaire de création, afficher les agents existants et gérer l'upload de fichiers de connaissance.
+
+Capacités activées
+------------------
+- React + TypeScript
+- API Tauri (`invoke`)
+- Gestion d'état avec `useState` / `useEffect`
+- Intégration d'un composant `AgentCard` pour l'affichage des agents
+- Support d'upload de fichiers et sélection de modèles via `<select>`
+
+Contraintes
+-----------
+- Fichier à créer : `src/components/AgentCreator.tsx`
+- Utiliser `invoke('create_agent', {...})` et `invoke('list_agents')`
+- Rafraîchir la liste des agents après création
+- Upload : convertir les fichiers en base64 ou envoyer leur chemin à `create_agent`
+- Modèles : exposer un tableau local de modèles (`llama3`, `mistral`, etc.)
+- Affichage : chaque agent renvoyé par `list_agents` est rendu via `AgentCard`
+- Fournir gestion d'erreurs basique (logs console)
+
+Mémoire
+-------
+- Ajouter `AgentCreator.tsx`
+- Prévoir un composant `AgentCard` si absent
+- Documenter toute évolution future dans ce journal


### PR DESCRIPTION
## Summary
- add instructions file for AgentCreator component to call Tauri create_agent and list_agents

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689518b0f9e083339634742f675f615f