### PR TITLE
feat: add basic agent infrastructure

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,69 @@
+import { AgentCreator } from './components/AgentCreator';
+import { Orchestrator } from './core/orchestrator';
+import { useState } from 'react';
+
+function App() {
+  const [orchestrator] = useState(() => new Orchestrator());
+  const [input, setInput] = useState('');
+  const [response, setResponse] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+    
+    setIsLoading(true);
+    try {
+      await orchestrator.setGoal(input);
+      const result = await orchestrator.runTask(
+        input, 
+        ['general']
+      );
+      setResponse(result);
+    } catch (e) {
+      setResponse("Erreur lors de l'exécution");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="p-4 border-b bg-white">
+        <h1 className="text-2xl font-bold">Super Agent Party</h1>
+      </header>
+
+      <main className="p-4">
+        <AgentCreator />
+        
+        <div className="mt-6 border rounded-lg p-4 bg-white">
+          <form onSubmit={handleSubmit} className="flex gap-2">
+            <input
+              type="text"
+              value={input}
+              onChange={e => setInput(e.target.value)}
+              placeholder="Décris ton objectif..."
+              className="flex-1 p-2 border rounded"
+            />
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="bg-purple-600 text-white px-4 py-2 rounded disabled:opacity-50"
+            >
+              {isLoading ? 'En cours...' : 'Lancer'}
+            </button>
+          </form>
+          
+          {response && (
+            <div className="mt-4 p-3 bg-gray-50 rounded-lg">
+              <h3 className="font-medium mb-2">Réponse :</h3>
+              <p>{response}</p>
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}
+
+export default App;

--- a/src/api/ollama-api.ts
+++ b/src/api/ollama-api.ts
@@ -1,0 +1,34 @@
+export async function generateResponse(prompt: string, model: string = 'llama3'): Promise<string> {
+  try {
+    const response = await fetch('http://localhost:11434/api/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model,
+        prompt,
+        stream: false
+      })
+    });
+
+    if (!response.ok) {
+      throw new Error(`Ollama API error: ${response.status}`);
+    }
+
+    const data = await response.json();
+    return data.response || '';
+  } catch (error) {
+    console.error('Ollama API error:', error);
+    throw new Error('Impossible de contacter Ollama. Assurez-vous qu\'il est lancé.');
+  }
+}
+
+export async function getAvailableModels(): Promise<string[]> {
+  try {
+    const response = await fetch('http://localhost:11434/api/tags');
+    const data = await response.json();
+    return data.models?.map((m: any) => m.name) || ['llama3', 'phi3', 'mistral'];
+  } catch (error) {
+    console.error('Error fetching models:', error);
+    return ['llama3', 'phi3', 'mistral'];
+  }
+}

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,0 +1,82 @@
+#[tauri::command]
+pub async fn create_agent(name: String) -> Result<String, String> {
+  use std::fs;
+  use std::path::Path;
+
+  let agents_dir = std::env::current_dir()
+    .unwrap()
+    .join("src/agents")
+    .join(&name);
+
+  // Créer les dossiers nécessaires
+  let dirs = [
+    "knowledge",
+    "memory",
+    "tools",
+    "vector-store"
+  ];
+
+  for dir in &dirs {
+    let path = agents_dir.join(dir);
+    if !path.exists() {
+      fs::create_dir_all(&path).map_err(|e| e.to_string())?;
+    }
+  }
+
+  // Créer config.json minimal
+  let config = serde_json::json!({
+    "name": name,
+    "role": "Agent autonome",
+    "model": "",
+    "created_at": chrono::Utc::now().to_rfc3339(),
+    "status": "pending"
+  });
+
+  fs::write(
+    agents_dir.join("config.json"),
+    config.to_string()
+  ).map_err(|e| e.to_string())?;
+
+  Ok(format!("Agent '{}' créé avec succès.", name))
+}
+
+#[tauri::command]
+pub fn list_agents() -> Result<Vec<AgentConfig>, String> {
+  let agents_dir = std::env::current_dir()
+    .unwrap()
+    .join("src/agents");
+
+  if !agents_dir.exists() {
+    return Ok(vec![]);
+  }
+
+  let mut agents = Vec::new();
+  for entry in std::fs::read_dir(agents_dir).map_err(|e| e.to_string())? {
+    let entry = entry.map_err(|e| e.to_string())?;
+    let path = entry.path();
+    
+    if path.is_dir() {
+      let config_path = path.join("config.json");
+      if config_path.exists() {
+        let config_str = std::fs::read_to_string(config_path)
+          .map_err(|e| e.to_string())?;
+          
+        let config: AgentConfig = serde_json::from_str(&config_str)
+          .map_err(|e| e.to_string())?;
+          
+        agents.push(config);
+      }
+    }
+  }
+
+  Ok(agents)
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct AgentConfig {
+  name: String,
+  role: String,
+  model: String,
+  created_at: String,
+  status: String,
+}

--- a/src/components/AgentCreator.tsx
+++ b/src/components/AgentCreator.tsx
@@ -1,0 +1,60 @@
+import { invoke } from '@tauri-apps/api/tauri';
+import { useState, useEffect } from 'react';
+
+export function AgentCreator() {
+  const [agents, setAgents] = useState<any[]>([]);
+  const [isCreating, setIsCreating] = useState(false);
+
+  useEffect(() => {
+    loadAgents();
+  }, []);
+
+  const loadAgents = async () => {
+    const list = await invoke('list_agents');
+    setAgents(list as any[]);
+  };
+
+  const createAgent = async () => {
+    setIsCreating(true);
+    const name = prompt("Nom de l'agent ?");
+    if (!name) {
+      setIsCreating(false);
+      return;
+    }
+
+    try {
+      await invoke('create_agent', { name });
+      await loadAgents();
+    } catch (e) {
+      console.error("Erreur création agent", e);
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  return (
+    <div className="p-4 border rounded-lg bg-gray-50">
+      <h2 className="text-xl font-bold mb-3">Gestion des Agents</h2>
+      
+      <button
+        onClick={createAgent}
+        disabled={isCreating}
+        className={`bg-blue-600 text-white px-4 py-2 rounded-lg ${
+          isCreating ? 'opacity-50 cursor-not-allowed' : ''
+        }`}
+      >
+        {isCreating ? 'Création...' : '➕ Créer un agent'}
+      </button>
+
+      <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
+        {agents.map(agent => (
+          <div key={agent.name} className="border p-4 rounded-lg">
+            <h3 className="font-bold">{agent.name}</h3>
+            <p className="text-sm text-gray-600">Rôle : {agent.role}</p>
+            <p className="text-xs">Statut : {agent.status}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -1,0 +1,25 @@
+import { generateResponse } from '../api/ollama-api';
+
+export class Orchestrator {
+  private currentGoal: string | null = null;
+  private activeAgents: string[] = [];
+  private memory: { [key: string]: any } = {};
+
+  async setGoal(goal: string) {
+    this.currentGoal = goal;
+    this.memory.lastGoal = goal;
+    localStorage.setItem('orchestrator-memory', JSON.stringify(this.memory));
+  }
+
+  async runTask(task: string, agentNames: string[]): Promise<string> {
+    this.activeAgents = agentNames;
+    
+    const prompt = `
+      TÂCHE : ${task}
+      
+      AGIS COMME UN EXPERT. RÉPONDS EN FRANÇAIS.
+    `;
+    
+    return await generateResponse(prompt, 'llama3');
+  }
+}


### PR DESCRIPTION
## Summary
- add Tauri commands to create and list agents
- create minimal agent creation UI
- add orchestrator and Ollama API helpers

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6895193059408333a8a0f7db4f57ef31