### PR TITLE
feat: add tool interface and UI toggles

### DIFF
--- a/codex_tools-2025-08-07.md
+++ b/codex_tools-2025-08-07.md
@@ -1,0 +1,4 @@
+# Tool system update
+- Added cross-language `Tool` interface and examples.
+- Added UI toggles to enable/disable tools per agent.
+- Documented usage in `doc/tools.md`.

--- a/doc/tools.md
+++ b/doc/tools.md
@@ -1,0 +1,36 @@
+# Tools Interface
+
+This document describes the tool system used by agents.
+
+## Interface
+
+### TypeScript
+
+```typescript
+export interface Tool {
+  name: string;
+  description: string;
+  handler: (input: string) => Promise<string> | string;
+}
+```
+
+### Rust
+
+```rust
+pub struct ToolMetadata {
+    pub name: &'static str,
+    pub description: &'static str,
+}
+
+pub trait Tool {
+    fn metadata(&self) -> ToolMetadata;
+    fn handle(&self, input: String) -> anyhow::Result<String>;
+}
+```
+
+## Built-in Examples
+
+- **shell** – execute shell commands.
+- **web-fetch** – fetch the body of a URL.
+
+Agents can enable or disable each tool in the agent configuration dialog.

--- a/src-tauri/src/tools/mod.rs
+++ b/src-tauri/src/tools/mod.rs
@@ -1,0 +1,12 @@
+pub struct ToolMetadata {
+    pub name: &'static str,
+    pub description: &'static str,
+}
+
+pub trait Tool {
+    fn metadata(&self) -> ToolMetadata;
+    fn handle(&self, input: String) -> anyhow::Result<String>;
+}
+
+pub mod shell;
+pub mod web_fetch;

--- a/src-tauri/src/tools/shell.rs
+++ b/src-tauri/src/tools/shell.rs
@@ -1,0 +1,18 @@
+use super::{Tool, ToolMetadata};
+use std::process::Command;
+
+pub struct Shell;
+
+impl Tool for Shell {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            name: "shell",
+            description: "Execute shell commands",
+        }
+    }
+
+    fn handle(&self, input: String) -> anyhow::Result<String> {
+        let output = Command::new("sh").arg("-c").arg(input).output()?;
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    }
+}

--- a/src-tauri/src/tools/web_fetch.rs
+++ b/src-tauri/src/tools/web_fetch.rs
@@ -1,0 +1,17 @@
+use super::{Tool, ToolMetadata};
+
+pub struct WebFetch;
+
+impl Tool for WebFetch {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            name: "web-fetch",
+            description: "Fetch content from a URL",
+        }
+    }
+
+    fn handle(&self, input: String) -> anyhow::Result<String> {
+        let body = reqwest::blocking::get(&input)?.text()?;
+        Ok(body)
+    }
+}

--- a/src/tools/shell.ts
+++ b/src/tools/shell.ts
@@ -1,0 +1,16 @@
+import { Tool } from './tool';
+import { exec } from 'child_process';
+
+export const shell: Tool = {
+  name: 'shell',
+  description: 'Execute shell commands',
+  handler: (cmd: string) => new Promise((resolve, reject) => {
+    exec(cmd, (err, stdout, stderr) => {
+      if (err) {
+        reject(stderr || err.message);
+      } else {
+        resolve(stdout);
+      }
+    });
+  })
+};

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -1,0 +1,5 @@
+export interface Tool {
+  name: string;
+  description: string;
+  handler: (input: string) => Promise<string> | string;
+}

--- a/src/tools/web-fetch.ts
+++ b/src/tools/web-fetch.ts
@@ -1,0 +1,10 @@
+import { Tool } from './tool';
+
+export const webFetch: Tool = {
+  name: 'web-fetch',
+  description: 'Fetch content from a URL',
+  handler: async (url: string) => {
+    const res = await fetch(url);
+    return await res.text();
+  }
+};

--- a/static/index.html
+++ b/static/index.html
@@ -4443,6 +4443,13 @@ if ('serviceWorker' in navigator) {
                                 <div class="knowledge-name">{{ t('deepResearch') }}</div>
                               </div>
                             </div>
+                            <div class="knowledge-item" v-for="tool in availableTools" :key="tool.name">
+                              <el-switch v-model="newAgent.tools[tool.name]"></el-switch>
+                              <div class="knowledge-info">
+                                <div class="knowledge-name">{{ tool.name }}</div>
+                                <div class="knowledge-desc">{{ tool.description }}</div>
+                              </div>
+                            </div>
                           </div>
                         </el-tab-pane>
                       </el-tabs>

--- a/static/js/vue_data.js
+++ b/static/js/vue_data.js
@@ -307,6 +307,10 @@ let vue_data = {
     ],
     showRestartDialog: false,
     agents: {},
+    availableTools: [
+      { name: 'shell', description: 'Execute shell commands' },
+      { name: 'web-fetch', description: 'Fetch content from a URL' }
+    ],
     showAgentForm: false,
     editingAgent: null,
     showAgentDialog: false,
@@ -314,7 +318,11 @@ let vue_data = {
     newAgent: {
       id: '',
       name: '',
-      system_prompt: ''
+      system_prompt: '',
+      tools: {
+        shell: false,
+        'web-fetch': false
+      }
     },
     editingAgent: false,
     currentLanguage: 'zh-CN',

--- a/static/js/vue_methods.js
+++ b/static/js/vue_methods.js
@@ -2675,7 +2675,8 @@ let vue_methods = {
         type: 'save_agent',
         data: {
           name: this.newAgent.name,
-          system_prompt: this.newAgent.system_prompt
+          system_prompt: this.newAgent.system_prompt,
+          tools: this.newAgent.tools
         }
       };
       this.ws.send(JSON.stringify(payload));
@@ -2683,7 +2684,11 @@ let vue_methods = {
       this.newAgent = {
         id: '',
         name: '',
-        system_prompt: ''
+        system_prompt: '',
+        tools: {
+          shell: false,
+          'web-fetch': false
+        }
       };
     },
     copyAgentId(id) {


### PR DESCRIPTION
## Summary
- define cross-language `Tool` interfaces in TypeScript and Rust with metadata and handler
- add example `shell` and `web-fetch` tools
- enable per-agent tool toggles and document usage

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68951d7334d88333b68d23ff69273457