### PR TITLE
feat: add axum server for agents

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -1,0 +1,33 @@
+# API Endpoints
+
+Les points d'accès HTTP exposés par l'application Tauri.
+
+Base URL: `http://localhost:3001`
+
+## GET /agents
+
+Retourne la liste des agents en mémoire.
+
+```bash
+curl http://localhost:3001/agents
+```
+
+## POST /agents
+
+Crée un nouvel agent.
+
+```bash
+curl -X POST http://localhost:3001/agents \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Alice"}'
+```
+
+## DELETE /agents/{id}
+
+Supprime l'agent correspondant à l'identifiant.
+
+```bash
+curl -X DELETE http://localhost:3001/agents/1
+```
+
+Le serveur est configuré avec CORS permissif pour accepter les requêtes depuis `localhost`.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "super-agent-party"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+axum = "0.7"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tower-http = { version = "0.4", features = ["cors"] }
+tauri = { version = "1", features = ["api-all"] }

--- a/src-tauri/src/http.rs
+++ b/src-tauri/src/http.rs
@@ -1,0 +1,75 @@
+use std::{net::SocketAddr, sync::{Arc, Mutex}};
+
+use axum::{
+    extract::{Path, State},
+    routing::{delete, get, post},
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
+use tower_http::cors::{Any, CorsLayer};
+
+#[derive(Serialize, Clone)]
+pub struct Agent {
+    pub id: usize,
+    pub name: String,
+}
+
+#[derive(Default)]
+struct AppState {
+    agents: Mutex<Vec<Agent>>,
+}
+
+async fn list_agents(State(state): State<Arc<AppState>>) -> Json<Vec<Agent>> {
+    let agents = state.agents.lock().unwrap().clone();
+    Json(agents)
+}
+
+#[derive(Deserialize)]
+struct NewAgent {
+    name: String,
+}
+
+async fn create_agent(
+    State(state): State<Arc<AppState>>,
+    Json(payload): Json<NewAgent>,
+) -> Json<Agent> {
+    let mut agents = state.agents.lock().unwrap();
+    let id = agents.len() + 1;
+    let agent = Agent {
+        id,
+        name: payload.name,
+    };
+    agents.push(agent.clone());
+    Json(agent)
+}
+
+async fn delete_agent(Path(id): Path<usize>, State(state): State<Arc<AppState>>) -> Json<bool> {
+    let mut agents = state.agents.lock().unwrap();
+    let len_before = agents.len();
+    agents.retain(|a| a.id != id);
+    Json(len_before != agents.len())
+}
+
+pub fn start_server() {
+    let state = Arc::new(AppState::default());
+
+    let app = Router::new()
+        .route("/agents", get(list_agents).post(create_agent))
+        .route("/agents/:id", delete(delete_agent))
+        .with_state(state)
+        .layer(
+            CorsLayer::new()
+                .allow_origin(Any)
+                .allow_methods(Any)
+                .allow_headers(Any),
+        );
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3001));
+    let rt = tokio::runtime::Runtime::new().expect("failed to build runtime");
+    rt.block_on(async move {
+        axum::Server::bind(&addr)
+            .serve(app.into_make_service())
+            .await
+            .unwrap();
+    });
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,0 +1,16 @@
+#![cfg_attr(
+    all(not(debug_assertions), target_os = "windows"),
+    windows_subsystem = "windows"
+)]
+
+mod http;
+
+fn main() {
+    std::thread::spawn(|| {
+        http::start_server();
+    });
+
+    tauri::Builder::default()
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}


### PR DESCRIPTION
## Summary
- add axum HTTP server with `/agents` routes
- start server thread on Tauri launch
- document API endpoints

## Testing
- `cargo check` *(fails: libsoup-2.4 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68951d7caec88333861c7cfa256624d2