### PR TITLE
feat: add agent dashboard and routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,13 @@
   "devDependencies": {
     "cross-env": "^7.0.3",
     "electron": "^33.0.1",
-    "electron-builder": "^24.9.1"
+    "electron-builder": "^24.9.1",
+    "typescript": "^5.4.0",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@types/react-router-dom": "^5.3.3",
+    "postcss": "^8.4.23",
+    "autoprefixer": "^10.4.16"
   },
   "dependencies": {
     "@electron/remote": "^2.1.3",
@@ -143,6 +149,11 @@
     "form-data": "^4.0.4",
     "markdown-it": "^14.1.0",
     "three": "^0.178.0",
-    "vue": "^3.5.17"
+    "vue": "^3.5.17",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3",
+    "@tauri-apps/api": "^1.5.3",
+    "tailwindcss": "^3.4.1"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
+import AgentDashboard from './components/AgentDashboard';
+
+function Tasks() {
+  return <div className="p-4"><h1 className="text-xl font-bold">Tasks</h1></div>;
+}
+
+function Settings() {
+  return <div className="p-4"><h1 className="text-xl font-bold">Settings</h1></div>;
+}
+
+export default function App() {
+  return (
+    <Router>
+      <nav className="p-4 flex gap-4 border-b mb-4">
+        <Link className="focus:outline-none focus:ring-2 focus:ring-blue-400" to="/agents">Agents</Link>
+        <Link className="focus:outline-none focus:ring-2 focus:ring-blue-400" to="/tasks">Tasks</Link>
+        <Link className="focus:outline-none focus:ring-2 focus:ring-blue-400" to="/settings">Settings</Link>
+      </nav>
+      <Routes>
+        <Route path="/agents" element={<AgentDashboard />} />
+        <Route path="/tasks" element={<Tasks />} />
+        <Route path="/settings" element={<Settings />} />
+      </Routes>
+    </Router>
+  );
+}

--- a/src/api/agents.ts
+++ b/src/api/agents.ts
@@ -1,0 +1,18 @@
+import { invoke } from '@tauri-apps/api/tauri';
+
+export interface Agent {
+  id: string;
+  name: string;
+}
+
+export async function listAgents(): Promise<Agent[]> {
+  return await invoke<Agent[]>('list_agents');
+}
+
+export async function createAgent(name: string): Promise<Agent> {
+  return await invoke<Agent>('create_agent', { name });
+}
+
+export async function deleteAgent(id: string): Promise<void> {
+  await invoke('delete_agent', { id });
+}

--- a/src/components/AgentDashboard.tsx
+++ b/src/components/AgentDashboard.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useState, FormEvent } from 'react';
+import { createAgent, deleteAgent, listAgents, Agent } from '../api/agents';
+
+export default function AgentDashboard() {
+  const [agents, setAgents] = useState<Agent[]>([]);
+  const [name, setName] = useState('');
+
+  useEffect(() => {
+    listAgents().then(setAgents);
+  }, []);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!name.trim()) return;
+    const agent = await createAgent(name.trim());
+    setAgents([...agents, agent]);
+    setName('');
+  }
+
+  async function handleDelete(id: string) {
+    await deleteAgent(id);
+    setAgents(agents.filter(a => a.id !== id));
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Agents</h1>
+      <form onSubmit={handleSubmit} className="flex gap-2 mb-4">
+        <label htmlFor="agent-name" className="sr-only">Agent Name</label>
+        <input
+          id="agent-name"
+          type="text"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          className="border p-2 flex-1 focus:outline-none focus:ring-2 focus:ring-blue-400"
+          placeholder="New agent name"
+        />
+        <button
+          type="submit"
+          className="bg-blue-500 text-white px-4 py-2 rounded focus:outline-none focus:ring-2 focus:ring-blue-400 hover:bg-blue-600"
+        >
+          Create
+        </button>
+      </form>
+      <ul className="space-y-2">
+        {agents.map(agent => (
+          <li key={agent.id} className="flex items-center justify-between border p-2 rounded">
+            <span>{agent.name}</span>
+            <button
+              onClick={() => handleDelete(agent.id)}
+              className="bg-red-500 text-white px-2 py-1 rounded focus:outline-none focus:ring-2 focus:ring-red-400 hover:bg-red-600"
+              aria-label={`Delete ${agent.name}`}
+            >
+              Delete
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add agents API for centralized invoke calls
- implement AgentDashboard component for creating, listing, and deleting agents
- introduce React Router navigation between agents, tasks, and settings

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68951d7adbe88333bcd5cb97d7eb61b1