### PR TITLE
feat: expand health endpoint

### DIFF
--- a/main.js
+++ b/main.js
@@ -292,9 +292,15 @@ async function waitForBackend() {
     try {
       const response = await fetch(`http://${HOST}:${PORT}/health`)
       if (response.ok) {
+        const data = await response.json()
         // 后端服务准备就绪，通知骨架屏页面
         if (mainWindow && !mainWindow.isDestroyed()) {
-          mainWindow.webContents.send('backend-ready', { port: PORT })
+          mainWindow.webContents.send('backend-ready', {
+            port: PORT,
+            version: data.version,
+            startTime: data.start_time,
+            dependencies: data.dependencies
+          })
         }
         return
       }

--- a/server.py
+++ b/server.py
@@ -38,6 +38,8 @@ from fastapi import status
 from fastapi.responses import JSONResponse, StreamingResponse
 import uuid
 import time
+import importlib
+from datetime import datetime
 from typing import Any, List, Dict,Optional
 import shortuuid
 from py.mcp_clients import McpClient
@@ -92,6 +94,20 @@ ALLOWED_VIDEO_EXTENSIONS = ['mp4', 'avi', 'mov', 'wmv', 'flv', 'mkv', 'webm', '3
 from py.get_setting import load_settings,save_settings,base_path,configure_host_port,UPLOAD_FILES_DIR,AGENT_DIR,MEMORY_CACHE_DIR,KB_DIR,DEFAULT_VRM_DIR,USER_DATA_DIR
 from py.llm_tool import get_image_base64,get_image_media_type
 
+with open(os.path.join(base_path, "package.json"), "r", encoding="utf-8") as f:
+    VERSION = json.load(f).get("version", "unknown")
+START_TIME = datetime.utcnow().isoformat()
+
+
+def check_dependency(module_name: str) -> str:
+    try:
+        importlib.import_module(module_name)
+        return "ok"
+    except Exception as e:
+        return f"error: {e}"
+
+
+MAIN_DEPENDENCIES = ["edge_tts", "openai"]
 
 configure_host_port(args.host, args.port)
 
@@ -4025,7 +4041,13 @@ async def initialize_a2a(request: Request):
 # 在现有路由之后添加health路由
 @app.get("/health")
 async def health_check():
-    return {"status": "ok"}
+    deps = {dep: check_dependency(dep) for dep in MAIN_DEPENDENCIES}
+    return {
+        "status": "ok",
+        "version": VERSION,
+        "start_time": START_TIME,
+        "dependencies": deps,
+    }
 
 
 @app.post("/load_file")


### PR DESCRIPTION
## Summary
- expand `/health` to report version, startup time, and dependency states
- forward health data in `waitForBackend` for UI display

## Testing
- `npm test` *(fails: Invalid package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68952b3d4c508333a16c2a9833e1b89d