### PR TITLE
feat: add WebGPU VRM canvas and React hook

### DIFF
--- a/codex_avatar3d-2025-08-07.md
+++ b/codex_avatar3d-2025-08-07.md
@@ -1,0 +1,4 @@
+# Avatar3D integration - 2025-08-07
+- add WebGPU canvas in static/vrm.html for VRM avatars
+- hook renderer to canvas and handle resize
+- expose useAvatar3D React hook for TTS and gestures

--- a/src/components/useAvatar3D.ts
+++ b/src/components/useAvatar3D.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+
+export function useAvatar3D() {
+  const wsRef = useRef<WebSocket | null>(null);
+  const [connected, setConnected] = useState(false);
+
+  useEffect(() => {
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const ws = new WebSocket(`${protocol}//${window.location.host}/ws/vrm`);
+    wsRef.current = ws;
+
+    ws.onopen = () => setConnected(true);
+    ws.onclose = () => setConnected(false);
+
+    return () => {
+      ws.close();
+    };
+  }, []);
+
+  const speak = useCallback((text: string) => {
+    wsRef.current?.send(JSON.stringify({ type: 'tts', text }));
+  }, []);
+
+  const gesture = useCallback((name: string) => {
+    wsRef.current?.send(JSON.stringify({ type: 'gesture', name }));
+  }, []);
+
+  return { connected, speak, gesture };
+}

--- a/static/js/vrm.js
+++ b/static/js/vrm.js
@@ -14,16 +14,15 @@ const isElectron = typeof require !== 'undefined' || navigator.userAgent.include
 document.body.classList.add(isElectron ? 'electron' : 'web');
 
 // 优化渲染器设置
+const canvas = document.getElementById('vrm-canvas');
 const renderer = new THREE.WebGPURenderer({
+    canvas: canvas || undefined,
     alpha: true,
     premultipliedAlpha: true,
     antialias: true,  // 添加抗锯齿
     powerPreference: "high-performance",  // 使用高性能GPU
     forceWebGL: false  // 确保使用WebGPU
 });
-
-// 添加性能优化设置
-renderer.setSize(window.innerWidth, window.innerHeight);
 renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2)); // 限制像素比例
 renderer.setClearColor(0x00000000, 0);
 
@@ -104,11 +103,25 @@ console.log(vrmPath);
 renderer.shadowMap.enabled = true;
 renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 
-document.body.appendChild( renderer.domElement );
+// 如果没有提供 canvas，自动添加
+if (!canvas) {
+    document.body.appendChild(renderer.domElement);
+}
+
+const initialWidth = canvas ? canvas.clientWidth : window.innerWidth;
+const initialHeight = canvas ? canvas.clientHeight : window.innerHeight;
 
 // camera
-const camera = new THREE.PerspectiveCamera( 30.0, window.innerWidth / window.innerHeight, 0.1, 20.0 );
-camera.position.set( 0.0, 1.0, 5.0 );
+const camera = new THREE.PerspectiveCamera(30.0, initialWidth / initialHeight, 0.1, 20.0);
+camera.position.set(0.0, 1.0, 5.0);
+renderer.setSize(initialWidth, initialHeight);
+window.addEventListener('resize', () => {
+    const width = canvas ? canvas.clientWidth : window.innerWidth;
+    const height = canvas ? canvas.clientHeight : window.innerHeight;
+    renderer.setSize(width, height);
+    camera.aspect = width / height;
+    camera.updateProjectionMatrix();
+});
 
 // camera controls
 const controls = new OrbitControls( camera, renderer.domElement );

--- a/static/vrm.html
+++ b/static/vrm.html
@@ -22,16 +22,19 @@
 			body {
 				margin: 0;
 			}
-			canvas {
-				display: block;
-			}
-		</style>
-	</head>
+                        canvas {
+                                display: block;
+                                width: 100vw;
+                                height: 100vh;
+                        }
+                </style>
+        </head>
 
-	<body>
-		<script type="importmap">
-			{
-				"imports": {
+        <body>
+                <canvas id="vrm-canvas"></canvas>
+                <script type="importmap">
+                        {
+                                "imports": {
 					"three": "./node_modules/three/build/three.webgpu.js",
 					"three/webgpu": "./node_modules/three/build/three.webgpu.js",
 					"three/tsl": "./node_modules/three/build/three.tsl.js",
@@ -41,7 +44,7 @@
 					"@pixiv/three-vrm-animation": "./node_modules/@pixiv/three-vrm-animation/lib/three-vrm-animation.module.js"
 				}
 			}
-		</script>
-		<script type="module" src="js/vrm.js"></script>
-	</body>
+                </script>
+                <script type="module" src="js/vrm.js"></script>
+        </body>
 </html>


### PR DESCRIPTION
## Summary
- add dedicated WebGPU canvas for VRM avatars
- handle renderer resizing and camera aspect
- expose `useAvatar3D` hook to send TTS and gesture events

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68952db241cc833388f650941ef9a1de