### PR TITLE
feat: support persona customization and memory retrieval

### DIFF
--- a/src/components/AgentCreator.tsx
+++ b/src/components/AgentCreator.tsx
@@ -3,15 +3,28 @@ import { useState, useEffect } from 'react';
 
 export function AgentCreator() {
   const [agents, setAgents] = useState<any[]>([]);
+  const [personas, setPersonas] = useState<any[]>([]);
   const [isCreating, setIsCreating] = useState(false);
 
   useEffect(() => {
     loadAgents();
+    loadPersonas();
   }, []);
 
   const loadAgents = async () => {
     const list = await invoke('list_agents');
     setAgents(list as any[]);
+  };
+
+  const loadPersonas = async () => {
+    const list = (await invoke('list_personas')) as any[];
+    const enriched = await Promise.all(
+      list.map(async p => {
+        const memory = await invoke('get_persona_memory', { id: p.id, query: '' });
+        return { ...p, memory };
+      })
+    );
+    setPersonas(enriched);
   };
 
   const createAgent = async () => {
@@ -22,9 +35,20 @@ export function AgentCreator() {
       return;
     }
 
+    const voice = prompt('Voix ?') || '';
+    const style = prompt('Style ?') || '';
+    const prompts = (prompt('Prompts système (séparés par \n)') || '')
+      .split('\n')
+      .filter(p => p.trim());
+    const tools = (prompt('Outils (séparés par ,)') || '')
+      .split(',')
+      .map(t => t.trim())
+      .filter(Boolean);
+
     try {
-      await invoke('create_agent', { name });
+      await invoke('create_agent', { name, persona: { voice, style, prompts, tools } });
       await loadAgents();
+      await loadPersonas();
     } catch (e) {
       console.error("Erreur création agent", e);
     } finally {
@@ -47,13 +71,31 @@ export function AgentCreator() {
       </button>
 
       <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
-        {agents.map(agent => (
-          <div key={agent.name} className="border p-4 rounded-lg">
-            <h3 className="font-bold">{agent.name}</h3>
-            <p className="text-sm text-gray-600">Rôle : {agent.role}</p>
-            <p className="text-xs">Statut : {agent.status}</p>
-          </div>
-        ))}
+        {agents.map(agent => {
+          const persona = personas.find(p => p.id === agent.name);
+          return (
+            <div key={agent.name} className="border p-4 rounded-lg">
+              <h3 className="font-bold">{agent.name}</h3>
+              <p className="text-sm text-gray-600">Rôle : {agent.role}</p>
+              <p className="text-xs">Statut : {agent.status}</p>
+              {persona && (
+                <div className="mt-2 text-xs">
+                  {persona.voice && <p>Voix : {persona.voice}</p>}
+                  {persona.style && <p>Style : {persona.style}</p>}
+                  {persona.prompts && persona.prompts.length > 0 && (
+                    <p>Prompts : {persona.prompts.join(', ')}</p>
+                  )}
+                  {persona.tools && persona.tools.length > 0 && (
+                    <p>Outils : {persona.tools.join(', ')}</p>
+                  )}
+                  {persona.memory && persona.memory.length > 0 && (
+                    <p>Mémoire : {persona.memory.join(' | ')}</p>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- allow persona configs with voice, style, prompts, and tools stored under user data directory
- expose utilities to save and list personas and fetch long term memory via mem0
- update AgentCreator UI to capture persona fields and display stored memory

## Testing
- `pytest`
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68952dbaecbc833388ddf78c76e40d82