### PR TITLE
docs: outline tool registry plugin workflow

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -1,0 +1,23 @@
+# Agent Task: Tool Registry & Plugin Loader
+
+## Prompt 1: Python Tool Registry
+- **Target**: `py/agent_tool.py`
+- Introduce a registry storing metadata for each tool: `name`, `description`, `schema`, `handler`.
+- Provide `register_tool`, `get_tool`, and `call_tool` helpers.
+- Validate payloads against JSON Schema before calling the handler.
+- Load tool plugins from a `plugins/` directory at runtime and register them automatically.
+
+## Prompt 2: TypeScript Tool Registry & Hot Plugins
+- **Target**: `src/tools/*`
+- Create `registry.ts` exposing `registerTool`, `getTool`, and `loadPlugins`.
+- Extend the `Tool` interface with a `schema` field.
+- Update existing tools (`shell.ts`, `web-fetch.ts`) to register themselves.
+- Support dynamic `import()` of plugin modules placed under `src/plugins`.
+
+## Prompt 3: CLI `agent add <repo-url>`
+- **Target**: new CLI script.
+- Implement command that clones the given repository into `plugins/`.
+- After cloning, invoke the registry loaders to activate the plugin tools without restarting.
+
+## Prompt 4: Tests
+- Add unit tests covering registry registration, plugin loading, and the CLI workflow.

--- a/codex_tool-registry-2025-08-07.md
+++ b/codex_tool-registry-2025-08-07.md
@@ -1,0 +1,4 @@
+# Tool registry and plugin system - 2025-08-07
+- design metadata-based registry across Python and TS
+- hot-load agents via plugin directories
+- add CLI command `agent add <repo-url>` for installing modules


### PR DESCRIPTION
## Summary
- add instructions for metadata-based tool registry and hot plugin loading
- log tool registry request for codex memory

## Testing
- `npm test` *(fails: Invalid package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68952dc183cc83339bd5ffa7ee22ee85