### PR TITLE
feat: persist orchestrator logs

### DIFF
--- a/codex_orchestrator-2025-08-07.md
+++ b/codex_orchestrator-2025-08-07.md
@@ -2,4 +2,5 @@
 - add queue and internal JSON logging
 - allow sequential and parallel agent execution
 - expose getLogs() for UI
+- persist logs on disk and restore on startup
 - write unit tests for memory logging

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "@types/react-dom": "^18.2.7",
     "@types/react-router-dom": "^5.3.3",
     "postcss": "^8.4.23",
-    "autoprefixer": "^10.4.16"
+    "autoprefixer": "^10.4.16",
 
     "typescript": "^5.4.2",
     "jest": "^29.7.0",

--- a/src/core/orchestrator.ts
+++ b/src/core/orchestrator.ts
@@ -1,28 +1,4 @@
-import { generateResponse } from '../api/ollama-api';
-
-export class Orchestrator {
-  private currentGoal: string | null = null;
-  private activeAgents: string[] = [];
-  private memory: { [key: string]: any } = {};
-
-  async setGoal(goal: string) {
-    this.currentGoal = goal;
-    this.memory.lastGoal = goal;
-    localStorage.setItem('orchestrator-memory', JSON.stringify(this.memory));
-  }
-
-  async runTask(task: string, agentNames: string[]): Promise<string> {
-    this.activeAgents = agentNames;
-    
-    const prompt = `
-      TÂCHE : ${task}
-      
-      AGIS COMME UN EXPERT. RÉPONDS EN FRANÇAIS.
-    `;
-    
-    return await generateResponse(prompt, 'llama3');
-
-import { promises as fs } from 'fs';
+import fs from 'fs';
 import path from 'path';
 
 export type AgentTask = () => Promise<any>;
@@ -40,6 +16,14 @@ export class Orchestrator {
 
   constructor(logDir = path.join(__dirname, '..', 'logs')) {
     this.logPath = path.join(logDir, 'logs.json');
+    if (fs.existsSync(this.logPath)) {
+      try {
+        const data = fs.readFileSync(this.logPath, 'utf-8');
+        this.logs = JSON.parse(data);
+      } catch {
+        this.logs = [];
+      }
+    }
   }
 
   enqueue(name: string, task: AgentTask) {
@@ -60,8 +44,8 @@ export class Orchestrator {
     const result = await entry.task();
     const log: LogEntry = { agent: entry.name, timestamp: Date.now(), result };
     this.logs.push(log);
-    await fs.mkdir(path.dirname(this.logPath), { recursive: true });
-    await fs.writeFile(this.logPath, JSON.stringify(this.logs, null, 2));
+    await fs.promises.mkdir(path.dirname(this.logPath), { recursive: true });
+    await fs.promises.writeFile(this.logPath, JSON.stringify(this.logs, null, 2));
   }
 
   getLogs(): LogEntry[] {

--- a/tests/orchestrator.test.ts
+++ b/tests/orchestrator.test.ts
@@ -33,4 +33,14 @@ describe('Orchestrator', () => {
     const logs = orch.getLogs();
     expect(logs.length).toBe(2);
   });
+
+  it('restores logs from file on initialization', async () => {
+    const orch1 = new Orchestrator(logDir);
+    orch1.enqueue('A', async () => 1);
+    await orch1.run('sequential');
+    const orch2 = new Orchestrator(logDir);
+    const logs = orch2.getLogs();
+    expect(logs.length).toBe(1);
+    expect(logs[0].agent).toBe('A');
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,15 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ESNext",
+    "module": "commonjs",
     "jsx": "react-jsx",
     "moduleResolution": "node",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
-  },
-  "include": ["src"]
-    "module": "commonjs",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
     "outDir": "dist"
   },
   "include": ["src/**/*", "tests/**/*"]
 }
+


### PR DESCRIPTION
## Summary
- persist orchestrator logs in a JSON file and load them on startup
- expose `getLogs()` and support sequential/parallel execution
- add unit tests for log persistence and execution modes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68953de3b64c83338287854a4de7f2b4