### PR TITLE
feat: add agent plugin CLI

### DIFF
--- a/codex_agent-cli-2025-08-08.md
+++ b/codex_agent-cli-2025-08-08.md
@@ -1,0 +1,4 @@
+# agent CLI plugin loader - 2025-08-08
+- add `agent add <repo-url>` CLI for cloning plugin repositories
+- auto reload plugin registry to activate tools without restart
+- introduce unit test covering plugin registration

--- a/py/__init__.py
+++ b/py/__init__.py
@@ -1,0 +1,1 @@
+# Package for agent plugins and tools

--- a/py/agent_cli.py
+++ b/py/agent_cli.py
@@ -1,0 +1,38 @@
+import argparse
+import os
+import subprocess
+from pathlib import Path
+
+from .plugin_registry import load_plugins
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+PLUGINS_DIR = BASE_DIR / "plugins"
+
+
+def add_repo(repo_url: str) -> None:
+    """Clone a repository into the plugins directory and reload plugins."""
+    PLUGINS_DIR.mkdir(parents=True, exist_ok=True)
+    repo_name = repo_url.rstrip("/").split("/")[-1]
+    if repo_name.endswith(".git"):
+        repo_name = repo_name[:-4]
+    dest = PLUGINS_DIR / repo_name
+    if dest.exists():
+        raise RuntimeError(f"Plugin {repo_name} already exists")
+    subprocess.check_call(["git", "clone", repo_url, str(dest)])
+    load_plugins(str(PLUGINS_DIR))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="agent")
+    sub = parser.add_subparsers(dest="command")
+    add = sub.add_parser("add", help="Add a plugin from a git repository")
+    add.add_argument("repo_url")
+    args = parser.parse_args()
+    if args.command == "add":
+        add_repo(args.repo_url)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/py/plugin_registry.py
+++ b/py/plugin_registry.py
@@ -1,0 +1,48 @@
+import importlib
+import os
+import sys
+from dataclasses import dataclass
+from types import ModuleType
+from typing import Callable, Dict
+
+@dataclass
+class Tool:
+    name: str
+    description: str
+    handler: Callable[[str], str]
+
+_registry: Dict[str, Tool] = {}
+
+
+def register_tool(tool: Tool) -> None:
+    """Register a tool in the global registry."""
+    _registry[tool.name] = tool
+
+
+def get_tool(name: str) -> Tool | None:
+    return _registry.get(name)
+
+
+def load_plugins(plugins_dir: str | None = None) -> None:
+    """Dynamically load plugins from the plugins directory."""
+    base_dir = os.path.dirname(os.path.dirname(__file__))
+    plugins_dir = plugins_dir or os.path.join(base_dir, "plugins")
+    if not os.path.isdir(plugins_dir):
+        return
+
+    if plugins_dir not in sys.path:
+        sys.path.insert(0, plugins_dir)
+
+    for entry in os.listdir(plugins_dir):
+        plugin_path = os.path.join(plugins_dir, entry)
+        if not os.path.isdir(plugin_path):
+            continue
+        try:
+            if plugin_path not in sys.path:
+                sys.path.insert(0, plugin_path)
+            module: ModuleType = importlib.import_module(entry)
+        except Exception:
+            continue
+        register = getattr(module, "register", None)
+        if callable(register):
+            register(register_tool)

--- a/tests/agent_cli_test.py
+++ b/tests/agent_cli_test.py
@@ -1,0 +1,44 @@
+import shutil
+import subprocess
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.modules.pop('py', None)
+
+from py import agent_cli
+from py.plugin_registry import get_tool, _registry
+
+
+def test_agent_add(tmp_path):
+    plugin_repo = tmp_path / "demo_plugin"
+    package_dir = plugin_repo / "demo_plugin"
+    package_dir.mkdir(parents=True)
+    (package_dir / "__init__.py").write_text(
+        """
+from dataclasses import dataclass
+
+@dataclass
+class Tool:
+    name: str
+    description: str
+    handler: callable
+
+def register(register_tool):
+    register_tool(Tool('echo', 'echo back', lambda x: x))
+"""
+    )
+    subprocess.check_call(["git", "init", str(plugin_repo)])
+    subprocess.check_call(["git", "-C", str(plugin_repo), "add", "."])
+    subprocess.check_call(["git", "-C", str(plugin_repo), "commit", "-m", "init"])
+
+    dest = Path(agent_cli.PLUGINS_DIR) / "demo_plugin"
+    if dest.exists():
+        shutil.rmtree(dest)
+    _registry.clear()
+    agent_cli.add_repo(str(plugin_repo))
+    tool = get_tool("echo")
+    assert tool is not None
+    assert tool.handler("hi") == "hi"
+    shutil.rmtree(dest)


### PR DESCRIPTION
## Summary
- add `agent add <repo-url>` CLI to clone plugins and reload tools
- introduce simple plugin registry with dynamic loader
- cover CLI and registry with unit test

## Testing
- `pytest tests/agent_cli_test.py -q`
- `npm test` *(fails: Invalid package.json JSON parse error)*

------
https://chatgpt.com/codex/tasks/task_e_68953dd7880c83338281059c732f5927