### PR TITLE
Add tests for tool registry and plugin workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,6 +188,7 @@ botpy.log*
 build.bat
 test*
 !tests/
+!tests/**
 wxauto*
 # Orchestrator logs
 src/logs/*.json

--- a/agent.py
+++ b/agent.py
@@ -1,0 +1,31 @@
+import argparse
+import subprocess
+from pathlib import Path
+from py.tool_registry import load_plugins
+
+def add(repo_url: str, plugins_dir: str = "plugins") -> None:
+    """Clone a plugin repository and activate its tools."""
+    plugins_path = Path(plugins_dir)
+    plugins_path.mkdir(exist_ok=True)
+    dest = plugins_path / Path(repo_url).name
+    subprocess.run([
+        "git",
+        "clone",
+        repo_url,
+        str(dest)
+    ], check=True)
+    load_plugins(str(plugins_path))
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="agent")
+    sub = parser.add_subparsers(dest="command")
+    add_p = sub.add_parser("add")
+    add_p.add_argument("repo_url")
+    args = parser.parse_args()
+    if args.command == "add":
+        add(args.repo_url)
+    else:
+        parser.print_help()
+
+if __name__ == "__main__":
+    main()

--- a/py/tool_registry.py
+++ b/py/tool_registry.py
@@ -1,0 +1,49 @@
+from typing import Callable, Dict, Any
+import importlib
+import os
+import sys
+from pathlib import Path
+
+_registry: Dict[str, Dict[str, Any]] = {}
+
+def register_tool(name: str, description: str, schema: Dict[str, Any], handler: Callable[[Dict[str, Any]], Any]) -> None:
+    """Register a tool with metadata and handler."""
+    _registry[name] = {
+        "name": name,
+        "description": description,
+        "schema": schema,
+        "handler": handler,
+    }
+
+def get_tool(name: str) -> Dict[str, Any] | None:
+    """Retrieve a tool by name."""
+    return _registry.get(name)
+
+def call_tool(name: str, payload: Dict[str, Any]) -> Any:
+    """Validate payload against schema and invoke the tool handler."""
+    tool = get_tool(name)
+    if not tool:
+        raise KeyError(f"Tool {name} not found")
+    schema = tool.get("schema", {})
+    for key in schema.get("required", []):
+        if key not in payload:
+            raise ValueError(f"Missing required field: {key}")
+    return tool["handler"](payload)
+
+def load_plugins(directory: str = "plugins") -> None:
+    """Dynamically load plugin packages from a directory."""
+    dir_path = Path(directory)
+    if not dir_path.is_dir():
+        return
+    sys.path.insert(0, str(dir_path.resolve()))
+    for item in dir_path.iterdir():
+        if item.is_dir() and (item / "__init__.py").exists():
+            if item.name in sys.modules:
+                del sys.modules[item.name]
+            module = importlib.import_module(item.name)
+            if hasattr(module, "setup"):
+                module.setup(register_tool)
+
+def clear_registry() -> None:
+    """Reset the tool registry (for testing)."""
+    _registry.clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import sys
+import types
+import importlib.util
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1]
+py_dir = root / "py"
+
+# Create a lightweight 'py' package pointing to our local modules
+package = types.ModuleType("py")
+package.__path__ = [str(py_dir)]
+sys.modules.setdefault("py", package)
+
+# Pre-load tool_registry so imports succeed
+spec = importlib.util.spec_from_file_location("py.tool_registry", py_dir / "tool_registry.py")
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+sys.modules["py.tool_registry"] = module

--- a/tests/test_agent_add_cli.py
+++ b/tests/test_agent_add_cli.py
@@ -1,0 +1,37 @@
+import subprocess
+from pathlib import Path
+import importlib.util
+
+from py.tool_registry import get_tool, clear_registry
+
+root = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location("agent", root / "agent.py")
+agent = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(agent)
+
+
+def setup_function():
+    clear_registry()
+
+
+def test_agent_add_clones_and_activates(tmp_path):
+    plugin_repo = tmp_path / "sample_plugin"
+    plugin_repo.mkdir()
+    (plugin_repo / "__init__.py").write_text(
+        "def setup(register):\n"
+        "    schema = {\"type\": \"object\", \"required\": [\"y\"]}\n"
+        "    def handler(p):\n"
+        "        return p['y'] * 3\n"
+        "    register('triple', 'triple numbers', schema, handler)\n"
+    )
+    subprocess.run(["git", "init"], cwd=plugin_repo, check=True, stdout=subprocess.PIPE)
+    subprocess.run(["git", "add", "__init__.py"], cwd=plugin_repo, check=True, stdout=subprocess.PIPE)
+    subprocess.run([
+        "git", "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init"
+    ], cwd=plugin_repo, check=True, stdout=subprocess.PIPE)
+
+    agent.add(str(plugin_repo), plugins_dir=str(tmp_path / "plugins"))
+    tool = get_tool("triple")
+    assert tool is not None
+    assert tool["handler"]({"y": 2}) == 6
+    assert (tmp_path / "plugins" / plugin_repo.name).exists()

--- a/tests/test_plugin_loading.py
+++ b/tests/test_plugin_loading.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+from py.tool_registry import load_plugins, get_tool, clear_registry
+
+
+def setup_function():
+    clear_registry()
+
+
+def test_dynamic_plugin_loading(tmp_path):
+    plugin_dir = tmp_path / "plugins"
+    pkg = plugin_dir / "sample_plugin"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text(
+        "def setup(register):\n"
+        "    schema = {\"type\": \"object\", \"required\": [\"x\"]}\n"
+        "    def handler(p):\n"
+        "        return p['x'] + 1\n"
+        "    register('increment', 'add one', schema, handler)\n"
+    )
+    load_plugins(str(plugin_dir))
+    tool = get_tool("increment")
+    assert tool is not None
+    assert tool["description"] == "add one"
+    assert tool["handler"]({"x": 1}) == 2

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1,0 +1,15 @@
+from py.tool_registry import register_tool, get_tool, call_tool, clear_registry
+
+
+def setup_function():
+    clear_registry()
+
+
+def test_register_and_get_tool():
+    def handler(payload):
+        return payload["value"] * 2
+    schema = {"type": "object", "required": ["value"]}
+    register_tool("doubler", "double numbers", schema, handler)
+    tool = get_tool("doubler")
+    assert tool["description"] == "double numbers"
+    assert call_tool("doubler", {"value": 3}) == 6


### PR DESCRIPTION
## Summary
- implement minimal tool registry with plugin loading
- add CLI `agent add` to clone and activate plugins
- cover tool registration, plugin loading, and CLI workflow with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68953dd5b2188333bc561782c81ee365