### PR TITLE
feat: add tool registry and plugin loader

### DIFF
--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -1,0 +1,29 @@
+import { Tool } from './tool';
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+
+const tools = new Map<string, Tool>();
+
+export function registerTool(tool: Tool): void {
+  tools.set(tool.name, tool);
+}
+
+export function getTool(name: string): Tool | undefined {
+  return tools.get(name);
+}
+
+export async function loadPlugins(): Promise<void> {
+  const pluginsDir = path.resolve(__dirname, '../plugins');
+  if (!fs.existsSync(pluginsDir)) {
+    return;
+  }
+
+  const files = fs.readdirSync(pluginsDir);
+  for (const file of files) {
+    if (file.endsWith('.ts') || file.endsWith('.js')) {
+      const modulePath = path.join(pluginsDir, file);
+      await import(pathToFileURL(modulePath).href);
+    }
+  }
+}

--- a/src/tools/shell.ts
+++ b/src/tools/shell.ts
@@ -1,9 +1,11 @@
 import { Tool } from './tool';
+import { registerTool } from './registry';
 import { exec } from 'child_process';
 
 export const shell: Tool = {
   name: 'shell',
   description: 'Execute shell commands',
+  schema: { type: 'string', description: 'Shell command to execute' },
   handler: (cmd: string) => new Promise((resolve, reject) => {
     exec(cmd, (err, stdout, stderr) => {
       if (err) {
@@ -14,3 +16,5 @@ export const shell: Tool = {
     });
   })
 };
+
+registerTool(shell);

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -1,5 +1,6 @@
 export interface Tool {
   name: string;
   description: string;
+  schema: unknown;
   handler: (input: string) => Promise<string> | string;
 }

--- a/src/tools/web-fetch.ts
+++ b/src/tools/web-fetch.ts
@@ -1,10 +1,14 @@
 import { Tool } from './tool';
+import { registerTool } from './registry';
 
 export const webFetch: Tool = {
   name: 'web-fetch',
   description: 'Fetch content from a URL',
+  schema: { type: 'string', description: 'URL to fetch' },
   handler: async (url: string) => {
     const res = await fetch(url);
     return await res.text();
   }
 };
+
+registerTool(webFetch);


### PR DESCRIPTION
## Summary
- add tool registry with plugin loader
- extend Tool interface to include schema
- self-register built-in tools

## Testing
- `npm test` *(fails: EJSONPARSE Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68953dd8f22883339142448ea8797b44