### PR TITLE
Use logger and robust error handling for custom HTTP

### DIFF
--- a/py/custom_http.py
+++ b/py/custom_http.py
@@ -1,5 +1,8 @@
 import aiohttp
 import json
+import logging
+
+logger = logging.getLogger(__name__)
 
 # 安全解析 JSON 的函数（用于 headers 是字符串的情况）
 def safe_json_loads(s):
@@ -13,7 +16,7 @@ async def fetch_custom_http(method, url, headers=None, body=None):
     if headers is None or headers == "":
         headers = {}
     elif isinstance(headers, str):
-        print(f'headers: {headers}')
+        logger.debug(f'headers: {headers}')
         headers = safe_json_loads(headers)
 
     # 自动处理 Content-Type，默认为 application/json
@@ -33,10 +36,11 @@ async def fetch_custom_http(method, url, headers=None, body=None):
     try:
         async with aiohttp.ClientSession() as session:
             async with session.request(method, url, **kwargs) as response:
-                print(f'Status: {response.status}')
+                response.raise_for_status()
+                logger.debug(f'Status: {response.status}')
                 response_text = await response.text()
-                print(f'Response: {response_text}')
+                logger.debug(f'Response: {response_text}')
                 return response_text
     except Exception as e:
-        print(f'Error: {e}')
-        return f'Error: {e}'
+        logger.exception("Error during HTTP request")
+        return {"error": str(e)}


### PR DESCRIPTION
## Summary
- replace print statements in custom HTTP helper with structured logging
- raise for non-success status codes
- return structured error info on exception

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68954731f704833393ca197c703a13e3