### PR TITLE
Use application timezone in tool message helper

### DIFF
--- a/server.py
+++ b/server.py
@@ -492,7 +492,7 @@ async def images_add_in_messages(request_messages: List[Dict], images: List[Dict
 
 async def tools_change_messages(request: ChatRequest, settings: dict):
     if settings['tools']['time']['enabled'] and settings['tools']['time']['triggerMode'] == 'beforeThinking':
-        time_message = f"消息发送时间：{local_timezone}  {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())}\n\n"
+        time_message = f"消息发送时间：{app.state.local_timezone}  {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())}\n\n"
         request.messages[-1]['content'] = time_message + request.messages[-1]['content']
     if settings['tools']['inference']['enabled']:
         inference_message = "回答用户前请先思考推理，再回答问题，你的思考推理的过程必须放在<think>与</think>之间。\n\n"


### PR DESCRIPTION
## Summary
- reference `app.state.local_timezone` in tool message injection

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'plugins.adder'; sqlite3.OperationalError: no such table: settings)*

------
https://chatgpt.com/codex/tasks/task_e_6895472eb62083339d662ecc2d6d4f3e