### PR TITLE
Improve plugin add command error handling

### DIFF
--- a/agent.js
+++ b/agent.js
@@ -3,10 +3,13 @@ const { spawnSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
-const [, , command, repo] = process.argv;
+const args = process.argv.slice(2);
+const command = args[0];
+const repo = args[1];
+const update = args.includes('--update') || args.includes('-u');
 
 function usage() {
-  console.log('Usage: agent add <repo-url>');
+  console.log('Usage: agent add <repo-url> [--update]');
   process.exit(1);
 }
 
@@ -19,18 +22,38 @@ if (!fs.existsSync(pluginsDir)) {
   fs.mkdirSync(pluginsDir, { recursive: true });
 }
 
-const clone = spawnSync('git', ['clone', repo], { cwd: pluginsDir, stdio: 'inherit' });
-if (clone.status !== 0) {
-  process.exit(clone.status || 1);
+const repoName = path.basename(repo, '.git').split('/').pop();
+const pluginPath = path.join(pluginsDir, repoName);
+
+if (fs.existsSync(pluginPath)) {
+  if (update) {
+    console.log(`Updating existing plugin ${repoName}...`);
+    const pull = spawnSync('git', ['pull'], { cwd: pluginPath, stdio: 'inherit' });
+    if (pull.status !== 0) {
+      console.error(`Failed to update plugin ${repoName}.`);
+      process.exit(pull.status || 1);
+    }
+  } else {
+    console.log(`Plugin ${repoName} already exists. Use --update to pull latest changes.`);
+    process.exit(0);
+  }
+} else {
+  const clone = spawnSync('git', ['clone', repo], { cwd: pluginsDir, stdio: 'inherit' });
+  if (clone.status !== 0) {
+    console.error(`Failed to clone repository ${repo}.`);
+    process.exit(clone.status || 1);
+  }
 }
 
 // copy frontend part if exists
-const repoName = path.basename(repo, '.git').split('/').pop();
-const pluginPath = path.join(pluginsDir, repoName);
 const pluginSrc = path.join(pluginPath, 'src');
 const targetSrc = path.resolve(__dirname, 'src/plugins', repoName);
 if (fs.existsSync(pluginSrc)) {
-  fs.cpSync(pluginSrc, targetSrc, { recursive: true });
+  try {
+    fs.cpSync(pluginSrc, targetSrc, { recursive: true });
+  } catch (err) {
+    console.error(`Failed to copy frontend files for ${repoName}:`, err.message);
+  }
 }
 
 // reload ts registry
@@ -39,4 +62,8 @@ const { reloadRegistry } = require('./src/tools/registry');
 reloadRegistry();
 
 // reload python registry
-spawnSync('python', ['-c', 'from py.agent_tool import reload_registry; reload_registry()'], { stdio: 'inherit' });
+const pyReload = spawnSync('python', ['-c', 'from py.agent_tool import reload_registry; reload_registry()'], { stdio: 'inherit' });
+if (pyReload.status !== 0) {
+  console.error('Failed to reload python registry.');
+  process.exit(pyReload.status || 1);
+}

--- a/codex_agent-plugin-update-2025-08-08.md
+++ b/codex_agent-plugin-update-2025-08-08.md
@@ -1,0 +1,6 @@
+# codex_agent-plugin-update-2025-08-08
+
+## Request
+- Verify existing `plugins/<repo>` before cloning, allow optional update.
+- Test `spawnSync` return codes and show clear failure messages.
+- Wrap `fs.cpSync` with try/catch to prevent silent failures.


### PR DESCRIPTION
## Summary
- Allow updating existing plugins instead of recloning
- Surface spawnSync failures with clear messages
- Guard plugin copying to avoid silent errors

## Testing
- `npm test` *(fails: jest not found)*
- `pytest` *(fails: ModuleNotFoundError: aiosqlite, fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6895467932288333ba0dab52e004b71a