### PR TITLE
feat(agent): handle existing clone with logging

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -1,20 +1,31 @@
 import argparse
+import logging
 import subprocess
 from pathlib import Path
 from py.tool_registry import load_plugins
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 def add(repo_url: str, plugins_dir: str = "plugins") -> None:
     """Clone a plugin repository and activate its tools."""
     plugins_path = Path(plugins_dir)
     plugins_path.mkdir(exist_ok=True)
     dest = plugins_path / Path(repo_url).name
-    subprocess.run([
-        "git",
-        "clone",
-        repo_url,
-        str(dest)
-    ], check=True)
+    if dest.exists():
+        logger.info("Repository %s exists, attempting to update", dest)
+        cmd = ["git", "-C", str(dest), "pull"]
+    else:
+        logger.info("Cloning %s into %s", repo_url, dest)
+        cmd = ["git", "clone", repo_url, str(dest)]
+    try:
+        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+        logger.debug("%s", result.stdout.strip())
+    except subprocess.CalledProcessError as e:
+        logger.error("%s", e.stderr.strip())
+        raise RuntimeError(f"git command failed: {e.stderr.strip()}") from e
     load_plugins(str(plugins_path))
+    logger.info("Plugins loaded from %s", plugins_path)
 
 def main() -> None:
     parser = argparse.ArgumentParser(prog="agent")

--- a/py/tool_registry.py
+++ b/py/tool_registry.py
@@ -40,6 +40,7 @@ def load_plugins(directory: str = "plugins") -> None:
         if item.is_dir() and (item / "__init__.py").exists():
             if item.name in sys.modules:
                 del sys.modules[item.name]
+            importlib.invalidate_caches()
             module = importlib.import_module(item.name)
             if hasattr(module, "setup"):
                 module.setup(register_tool)

--- a/tests/test_agent_add_cli.py
+++ b/tests/test_agent_add_cli.py
@@ -1,4 +1,5 @@
 import subprocess
+import time
 from pathlib import Path
 import importlib.util
 
@@ -35,3 +36,43 @@ def test_agent_add_clones_and_activates(tmp_path):
     assert tool is not None
     assert tool["handler"]({"y": 2}) == 6
     assert (tmp_path / "plugins" / plugin_repo.name).exists()
+
+
+def test_agent_add_updates_existing_repo(tmp_path):
+    plugin_repo = tmp_path / "sample_plugin"
+    plugin_repo.mkdir()
+    init_content = (
+        "def setup(register):\n"
+        "    schema = {\"type\": \"object\", \"required\": [\"y\"]}\n"
+        "    def handler(p):\n"
+        "        return p['y'] * 3\n"
+        "    register('triple', 'triple numbers', schema, handler)\n"
+    )
+    (plugin_repo / "__init__.py").write_text(init_content)
+    subprocess.run(["git", "init"], cwd=plugin_repo, check=True, stdout=subprocess.PIPE)
+    subprocess.run(["git", "add", "__init__.py"], cwd=plugin_repo, check=True, stdout=subprocess.PIPE)
+    subprocess.run([
+        "git", "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init"
+    ], cwd=plugin_repo, check=True, stdout=subprocess.PIPE)
+
+    plugins_dir = tmp_path / "plugins"
+    agent.add(str(plugin_repo), plugins_dir=str(plugins_dir))
+    tool = get_tool("triple")
+    assert tool["handler"]({"y": 2}) == 6
+
+    updated_content = (
+        "def setup(register):\n"
+        "    schema = {\"type\": \"object\", \"required\": [\"y\"]}\n"
+        "    def handler(p):\n"
+        "        return p['y'] * 5\n"
+        "    register('triple', 'triple numbers', schema, handler)\n"
+    )
+    (plugin_repo / "__init__.py").write_text(updated_content)
+    subprocess.run(["git", "add", "__init__.py"], cwd=plugin_repo, check=True, stdout=subprocess.PIPE)
+    subprocess.run([
+        "git", "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "update"
+    ], cwd=plugin_repo, check=True, stdout=subprocess.PIPE)
+    time.sleep(1)
+    agent.add(str(plugin_repo), plugins_dir=str(plugins_dir))
+    tool = get_tool("triple")
+    assert tool["handler"]({"y": 2}) == 10


### PR DESCRIPTION
## Summary
- avoid recloning existing plugin repos by pulling updates when destination exists
- capture git command output and log steps for easier debugging
- ensure plugin reload sees updates and add regression test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*
- `pytest tests/test_agent_add_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68954675a1e083338ed5200d0913d163