### PR TITLE
fix plugin loader for nested packages

### DIFF
--- a/codex_repo-review-2025-08-08.md
+++ b/codex_repo-review-2025-08-08.md
@@ -1,0 +1,4 @@
+# Repo Review Request
+- **Date:** 2025-08-08
+- **Request:** Evaluate repository quality and implement improvement for v1 readiness.
+- **Notes:** Added plugin loader fix and executed test suite (partial due to missing runtime dependencies).


### PR DESCRIPTION
## Summary
- handle plugin repositories that contain nested packages in `load_plugins`
- record repo review request

## Testing
- `pytest tests/agent_cli_test.py tests/test_agent_add_cli.py tests/test_plugin_loading.py`
- `pytest` *(fails: sqlite3.OperationalError: no such table: settings)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689845380b54833380f614d656e565c8